### PR TITLE
Small edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,16 +4,16 @@
 ## Condition table
 
 ```
-| parameters              | cofactored      | cofactorless                   | comment                            |
-|-------------------------+-----------------+--------------------------------+------------------------------------|
-| s = 0, R small, A small | always passes   | R = -k×A                       | see ed25519's verify_strict        |
-| s > 0, R small, A small | always fails    | always fails                   | no large order component on the r. |
-| s = 0, R mixed, A small | always fails    | always fails                   | no large order component on the l. |
-| s > 0, R mixed, A small | 8×s×B = 8×R     | 8×s×B = 8×R ∧ L×R = -L×k×A     | [1]                                |
-| s = 0, R small, A mixed | always fails    | always fails                   | no large order component on the l. |
-| s > 0, R small, A mixed | 8×s×B = 8×k×A   | 8×s×B = 8×k×A ∧ L×R = -L×k×A   | symmetric of [1]                   |
-| s = 0, R mixed, A mixed | 8×R = -8×k×A    | R = - k×A                      | hard to test (req. hash inversion) |
-| s > 0, R mixed, A mixed | 8×s×B = 8×R+k×A | 8×s×B = 8×R+k×A ∧ L×R = -L×k×A |                                    |
+| | parameters              | cofactored        | cofactorless                     | comment                               |
+|-+-------------------------+-------------------+----------------------------------+---------------------------------------|
+|1| S = 0, R small, A small | always passes     | R = -k×A                         | see ed25519's verify_strict           |
+|2| S > 0, R small, A small | always fails      | always fails                     | no large order component on the right |
+|3| S = 0, R mixed, A small | always fails      | always fails                     | no large order component on the left  |
+|4| S > 0, R mixed, A small | 8×S×B = 8×R       | 8×S×B = 8×R ∧ L×R = -L×k×A       | [*]                                   |
+|5| S = 0, R small, A mixed | always fails      | always fails                     | no large order component on the left  |
+|6| S > 0, R small, A mixed | 8×S×B = 8×k×A     | 8×S×B = 8×k×A ∧ L×R = -L×k×A     | symmetric of [*]                      |
+|7| S = 0, R mixed, A mixed | 8×R = -8×k×A      | R = -k×A                         | hard to test (req. hash inversion)    |
+|8| S > 0, R mixed, A mixed | 8×S×B = 8×R+8×k×A | 8×S×B = 8×R+8×k×A ∧ L×R = -L×k×A |                                       |
 ```
 
 Here "mixed" means with a strictly positive torsion component but not small,


### PR DESCRIPTION
* Rename small "s" to capital "S" (I think this is the wider notation - used in RFC and in NIST).
* Fix the equations on line 8 (8x was missing in 8xkxA).
* Add numbering for the ease of referencing.
* l. -> left, r. -> right (otherwise r looks like r in R = r * B and l looks like order L - I was confused for a couple of minutes)
* [1] -> [*] (not to mix with the numbering)