### PR TITLE
Pyca 3.0 w/ OpenSSL 1.1.1g support against ed25519 test vectors

### DIFF
--- a/scripts/pyca-openssl/eddsa_utils.py
+++ b/scripts/pyca-openssl/eddsa_utils.py
@@ -1,0 +1,19 @@
+import json
+
+from cryptography.hazmat.backends import default_backend
+from cryptography.hazmat.primitives.asymmetric import ed25519
+
+if __name__ == "__main__":
+    with open('../cases.json') as f:
+        data = json.load(f)
+    print('backend version text: ' + default_backend().openssl_version_text())
+    print('backend version num: {}'.format(default_backend().openssl_version_number()))
+    for i, test_case in enumerate(data):
+        try:
+            pub_key = ed25519.Ed25519PublicKey.from_public_bytes(bytes.fromhex(test_case['pub_key']))
+            msg = bytes.fromhex(test_case['message'])
+            sig = bytes.fromhex(test_case['signature'])
+            pub_key.verify(sig, msg)
+            print('{}: true'.format(i))
+        except:
+            print('{}: false'.format(i))


### PR DESCRIPTION
Pyca python cryptography against test vectors. Note that the backend in my laptop is using OpenSSL 1.1.1g (and pyca uses the default OpenSSL lib in each machine).

backend version text: OpenSSL 1.1.1g  21 Apr 2020
backend version num: 269488255
0: false
1: true
2: false
3: true
4: false
5: true
6: false
7: true
8: false
9: false