### PR TITLE
Tests for ref10 from SUPERCOP via Python bindings

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,8 @@ TODO
 - [npm's ed25519](https://www.npmjs.com/package/ed25519) in scripts/eddsa_test
 - [Pyca](https://cryptography.io/en/latest/)
 - [OpenSSL](https://github.com/openssl/openssl) in scripts openssl_3/test_script.sh
-- [tweetnacl](https://www.npmjs.com/package/tweetnacl) version 1.0.3 
+- [tweetnacl](https://www.npmjs.com/package/tweetnacl) version 1.0.3
+- [ref10 from SUPERCOP through Python bindings](https://github.com/warner/python-ed25519)
 
 ## Claimed (but feel free to steal)
 

--- a/scripts/python-ed25519.py
+++ b/scripts/python-ed25519.py
@@ -1,0 +1,32 @@
+# This code tests the python-ed25519 (https://github.com/warner/python-ed25519) that binds to
+# the C code of the SUPERCOP benchmark suite (http://bench.cr.yp.to/supercop.html).
+# To run this test:
+# > git clone git@github.com:warner/python-ed25519.git
+# Add the test below to src/ed25519/test_ed25519.py
+# > python setup.py build
+# > python setup.py test
+# The output is:
+# 0: false
+# 1: true
+# 2: false
+# 3: true
+# 4: false
+# 5: true
+# 6: false
+# 7: true
+# 8: false
+# 9: true
+
+def test_ours(self):
+    with open('../cases.json') as f:
+        data = json.load(f)
+        print('')
+    for i, test_case in enumerate(data):
+        try:
+            pub_key = ed25519.VerifyingKey(bytes.fromhex(test_case['pub_key']))
+            msg = bytes.fromhex(test_case['message'])
+            sig = bytes.fromhex(test_case['signature'])
+            pub_key.verify(sig, msg)
+            print('{}: true'.format(i))
+        except:
+            print('{}: false'.format(i))


### PR DESCRIPTION
This code tests the python-ed25519 (https://github.com/warner/python-ed25519) that binds to the C code of the SUPERCOP benchmark suite (http://bench.cr.yp.to/supercop.html) known as "ref10" original implementation.

To run this test:
> git clone git@github.com:warner/python-ed25519.git
Add the test below to src/ed25519/test_ed25519.py
> python setup.py build
> python setup.py test

The output is:
0: false
1: true
2: false
3: true
4: false
5: true
6: false
7: true
8: false
9: true