### PR TITLE
Clarification re BC and i2p Java libs

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,27 +53,30 @@ Besides small components, we also test:
   with a null high bit).
 - a "pre-reduced" scalar (vector 8), namely one that fails if the verification equation is
   `[8] R + [8 k] A = [8 s] B` rather than the recommended `[8] (R + k A) = [8] sB`.
-  (which passes cofactored, without pre-reduction)
-- a negative zero point in A (vectors 12 & 13)
+  (which passes cofactored, without pre-reduction).
+- a negative zero point in A (vectors 12 & 13).
 
 For a total of 15 test vectors.
 
 ## Verified libraries
 
-- [Dalek](https://github.com/dalek-cryptography/ed25519-dalek) : in unit tests
-- [Zebra](https://github.com/ZcashFoundation/ed25519-zebra) : in unit tests
+- [Apple CryptoKit](https://developer.apple.com/documentation/cryptokit) : in `scripts/ed25519-ios`
 - BoringSSL, through [Ring](https://github.com/briansmith/ring) : in unit tests
-- [Go-ed25519](https://golang.org/pkg/crypto/ed25519/) : in scripts/ed25519_test.go
-- [ed25519-java](https://github.com/str4d/ed25519-java) : in scripts/ed25519-java
-- [bouncycastle](https://www.bouncycastle.org/) : in scripts/ed25519-java
-- LibSodium, through [pynacl](https://github.com/pyca/pynacl) : in scripts/pynacl_test.py
-- [npm's ed25519](https://www.npmjs.com/package/ed25519) : in scripts/eddsa_test
-- [Pyca](https://cryptography.io/en/latest/) using OpenSSL 1.1.1g as default backend : in scripts/pyca-openssl
-- [OpenSSL](https://github.com/openssl/openssl) : in scripts openssl_3/test_script.sh
-- [tweetnacl](https://www.npmjs.com/package/tweetnacl) version 1.0.3 : in scripts/tweetnacl
-- [ref10 from SUPERCOP through Python bindings](https://github.com/warner/python-ed25519) : in scripts/python-ed25519.py
-- [ed25519-donna from Signal](https://github.com/signalapp/libsignal-protocol-c.git): in scripts/ed25519-signal-donna
-- ed25519 on nCipher, by Rob Starkey
+- [Bouncy Castle (Java)](https://www.bouncycastle.org/java.html) version 1.66 : in `scripts/ed25519-java`
+- [Dalek](https://github.com/dalek-cryptography/ed25519-dalek) : in unit tests
+- [ed25519-donna from Signal](https://github.com/signalapp/libsignal-protocol-c.git): in `scripts/ed25519-signal-donna`
+- [ed25519-java](https://github.com/str4d/ed25519-java) version 0.3.0 : in `scripts/ed25519-java`
+- [Go-ed25519](https://golang.org/pkg/crypto/ed25519/) : in `scripts/ed25519_test.go`
+- [libra-crypto](https://github.com/libra/libra/tree/master/crypto/crypto) : in unit tests
+- LibSodium, through [pynacl](https://github.com/pyca/pynacl) : in `scripts/pynacl_test.py`
+- nCipher's ed25519, by Rob Starkey
+- [npm's ed25519](https://www.npmjs.com/package/ed25519) : in `scripts/eddsa_test`
+- [OpenSSL](https://github.com/openssl/openssl) : in `scripts openssl_3/test_script.sh`
+- [Pyca](https://cryptography.io/en/latest/) using OpenSSL 1.1.1g as default backend : in `scripts/pyca-openssl`
+- [python-ed25519](https://github.com/warner/python-ed25519)) : in `scripts/python-ed25519`
+- [ref10 from SUPERCOP through Python bindings](https://github.com/warner/python-ed25519) : in `scripts/python-ed25519.py`
+- [tweetnacl](https://www.npmjs.com/package/tweetnacl) version 1.0.3 : in `scripts/tweetnacl`
+- [Zebra](https://github.com/ZcashFoundation/ed25519-zebra) : in unit tests
 
 ## Results
 
@@ -81,11 +84,11 @@ For a total of 15 test vectors.
 ┌---------------------------------------------------------------------------┐
 |Library        | 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9 | 10| 11| 12| 13| 14|
 |---------------+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---|
+|Apple CryptoKit| X | V | X | V | X | V | V | X | X | X | X | X | X | X | V |
+|---------------+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---|
 |BoringSSL      | X | V | X | V | X | V | V | X | X | X | X | X | X | X | V |
 |---------------+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---|
-|BouncyCastle   | X | V | X | V | X | V | V | X | X | X | X | X | X | X | X |
-|---------------+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---|
-|CryptoKit      | X | V | X | V | X | V | V | X | X | X | X | X | X | X | V |
+|Bouncy Castle  | X | V | X | V | X | V | V | X | X | X | X | X | X | X | X |
 |---------------+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---|
 |Dalek          | X | V | X | V | X | V | V | X | X | X | V | X | X | X | V |
 |---------------+---+---+---+---+---+---+---+---+---+---+---+---+---+---+---|

--- a/scripts/ed25519-java/README.md
+++ b/scripts/ed25519-java/README.md
@@ -3,6 +3,8 @@ Run from under IntelJ IDEA.
 Or set the CLASSPATH variable to point to all the jars in the dependencies and run
 `java -classpath $CLASSPATH TestVectorChecker`
 
+Note: A sample Maven `pom.xml` file with the required dependencies exists under the `/target` folder. 
+
 `java -version` outputs
 java version "1.8.0_181"
 Java(TM) SE Runtime Environment (build 1.8.0_181-b13)

--- a/scripts/ed25519-java/src/main/java/TestVectorChecker.java
+++ b/scripts/ed25519-java/src/main/java/TestVectorChecker.java
@@ -6,17 +6,6 @@ import java.io.FileReader;
 
 public class TestVectorChecker {
 
-    // --- OUTPUT ---
-    // 0: false
-    // 1: true
-    // 2: false
-    // 3: true
-    // 4: false
-    // 5: true
-    // 6: false
-    // 7: true
-    // 8: false
-    // 9: true
     public static void main(String[] args) throws FileNotFoundException {
         String jsonFilename = "../../cases.json";
         JsonReader reader = new JsonReader(new FileReader(jsonFilename));
@@ -24,7 +13,6 @@ public class TestVectorChecker {
 
         // For i2p ed25519-java
         System.out.print("|ed25519-java   |");
-        int index = 0;
         for (Ed25519TestCase testCase : testCases) {
             if (testCase.verify_i2p()) {
                 System.out.print(" V |");
@@ -36,7 +24,6 @@ public class TestVectorChecker {
 
         // For BC ed25519
         System.out.print("|BouncyCastle   |");
-        index = 0;
         for (Ed25519TestCase testCase : testCases) {
             if (testCase.verify_bc()) {
                 System.out.print(" V |");

--- a/scripts/ed25519-java/target/pom.xml
+++ b/scripts/ed25519-java/target/pom.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>org.example</groupId>
+    <artifactId>ed25519-rfc-compat</artifactId>
+    <version>1.0-SNAPSHOT</version>
+
+    <dependencies>
+        <dependency>
+            <groupId>net.i2p.crypto</groupId>
+            <artifactId>eddsa</artifactId>
+            <version>0.3.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.bouncycastle</groupId>
+            <artifactId>bcprov-jdk15on</artifactId>
+            <version>1.66</version>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+            <version>2.8.6</version>
+        </dependency>
+    </dependencies>
+</project>


### PR DESCRIPTION
+ Adding supported libs (sorted) to be compatible with our comparison table.
+ BC and i2p clean up code, versions and provide sample Maven `pom.xml` file for the required dependencies.
+ make it clear that we used the Java version of BC.