### PR TITLE
Just for fun, test vectors ran on hacl*

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2018"
 [dependencies]
 anyhow = "1.0.32"
 curve25519-dalek = "2.1.0"
+hacl-star = { git = "https://github.com/quininer/rust-hacl-star", version = "0.2.0"}
 hex = "0.4.2"
 rand = "0.7.3"
 sha2 = "0.9.1"

--- a/results.md
+++ b/results.md
@@ -6,6 +6,7 @@
 |ed25519-donna  | V | V | V | V | X | X | V | X | X | X | X | V |
 |ed25519-java   | V | V | V | V | X | X | V | V | X | X | V | X |
 |Go             | V | V | V | V | X | X | X | X | X | X | X | V |
+|Hacl*          | V | V | V | V | X | X | X | X | X | X | X | X |
 |libra-crypto   | X | X | X | V | X | X | X | X | X | X | X | X |
 |LibSodium      | X | X | X | V | X | X | X | X | X | X | X | X |
 |npm            | V | V | V | V | X | X | X | X | X | X | X | V |

--- a/src/main.rs
+++ b/src/main.rs
@@ -1087,6 +1087,17 @@ mod tests {
         (pk, sig)
     }
 
+    fn unpack_test_vector_hacl(
+        t: &TestVector,
+    ) -> (hacl_star::ed25519::PublicKey, hacl_star::ed25519::Signature) {
+        let mut sig_bytes = [0u8; 64];
+        sig_bytes.copy_from_slice(&t.signature[..]);
+
+        let pk = hacl_star::ed25519::PublicKey(t.pub_key);
+        let sig = hacl_star::ed25519::Signature(sig_bytes);
+        (pk, sig)
+    }
+
     fn unpack_test_vector_zebra(t: &TestVector) -> (ZPublicKey, ZSignature) {
         let pk = ZPublicKey::try_from(&t.pub_key[..]).unwrap();
         let sig = ZSignature::try_from(&t.signature[..]).unwrap();
@@ -1130,6 +1141,22 @@ mod tests {
             {
                 Ok(_v) => print!(" V |"),
                 Err(_e) => print!(" X |"),
+            }
+        }
+        println!();
+    }
+
+    #[test]
+    fn test_hacl() {
+        let vec = generate_test_vectors().unwrap();
+
+        print!("\n|Hacl*          |");
+        for tv in vec.iter() {
+            let (pk, sig) = unpack_test_vector_hacl(&tv);
+            if pk.verify(&tv.message[..], &sig) {
+                print!(" V |");
+            } else {
+                print!(" X |");
             }
         }
         println!();


### PR DESCRIPTION
Results:
```
|Hacl*          | V | V | V | V | X | X | X | X | X | X | X | X |
```

So Hacl* is cofactorless (vecs 4-5), checks for small scalars (vecs 6-7), has no check for small pubkeys or small R (vecs 0-3) and behaves correctly w.r.t scalar deserialization (vecs 6-7) and reduction (vecs 8-11) - the latter part of which is not suprising for a certified library.